### PR TITLE
Remove unreachable try catch

### DIFF
--- a/ts/client/src/smart-client.ts
+++ b/ts/client/src/smart-client.ts
@@ -124,30 +124,32 @@ export class SmartClient {
         }
     }
 
+    protected checkIfAborted<T>(res: T) {
+        // client will only ever return undefined if the query was cancelled
+        if (res === undefined) {
+            this.dispose();
+            throw new Error("Query has been cancelled");
+        }
+    }
+
     public async query<T extends QueryResultRow>(query: string, values?: any[]): Promise<QueryResult<T>> {
         this.ensureLiving();
 
-        try {
-            this.queryLogger?.(query, values);
-            return this.client.query<T>(query, values);
-        } catch (e) {
-            console.error(`Query failed`);
-            console.error(query, values);
-            throw e;
-        }
+        this.queryLogger?.(query, values);
+        const res = await this.client.query<T>(query, values);
+        this.checkIfAborted(res);
+
+        return res;
     }
 
     public async queryArray<T extends any[]>(query: string, values?: any[]): Promise<QueryArrayResult<T>> {
         this.ensureLiving();
 
-        try {
-            this.queryLogger?.(query, values);
-            return this.client.query<T>({ text: query, values, rowMode: "array" });
-        } catch (e) {
-            console.error(`Query failed`);
-            console.error(query, values);
-            throw e;
-        }
+        this.queryLogger?.(query, values);
+        const res = this.client.query<T>({ text: query, values, rowMode: "array" });
+        this.checkIfAborted(res);
+
+        return res;
     }
 
     public queryStream<T, O extends StreamOptions>(
@@ -161,11 +163,17 @@ export class SmartClient {
         try {
             this.queryLogger?.(query, values);
             const cursor = this.client.query(new Cursor(query, values));
+            this.checkIfAborted(cursor);
+
+            const abortCheck = this.checkIfAborted.bind(this);
+
             const batchSize = options.batchSize;
             if (batchSize === undefined) {
                 const generator = async function* () {
                     while (true) {
                         const result = await cursor.read(1);
+                        abortCheck(result);
+
                         if (result.length === 0) {
                             break;
                         }
@@ -179,6 +187,8 @@ export class SmartClient {
                 const generator = async function* () {
                     while (true) {
                         const result = await cursor.read(batchSize);
+                        abortCheck(result);
+
                         if (result.length === 0) {
                             break;
                         }
@@ -237,16 +247,19 @@ export class SmartClient {
             this.inTx = true;
 
             if (this.txDepth === 0) {
-                await this.client.query("BEGIN;");
+                const res = await this.client.query("BEGIN;");
+                this.checkIfAborted(res);
             } else {
-                await this.client.query(`SAVEPOINT S${this.txDepth};`);
+                const res = await this.client.query(`SAVEPOINT S${this.txDepth};`);
+                this.checkIfAborted(res);
             }
 
             this.active = false;
             const result = await CurrentTransaction.run(newClient, () => fn(newClient));
 
             if (this.txDepth === 0) {
-                await this.client.query("COMMIT;");
+                const res = await this.client.query("COMMIT;");
+                this.checkIfAborted(res);
             }
 
             // This is a bit of a misnomer in the sense that if this `tx` is not at the root
@@ -265,13 +278,15 @@ export class SmartClient {
             console.error("Error in transaction", e);
 
             if (this.txDepth === 0) {
-                await this.client.query("ROLLBACK;");
+                const res = await this.client.query("ROLLBACK;");
+                this.checkIfAborted(res);
 
                 this.active = true;
                 await newClient.trigger("rollback");
                 await this.trigger("rollback");
             } else {
-                await this.client.query(`ROLLBACK TO S${this.txDepth - 1}`);
+                const res = await this.client.query(`ROLLBACK TO S${this.txDepth - 1}`);
+                this.checkIfAborted(res);
 
                 this.active = true;
                 await newClient.trigger("rollback");

--- a/ts/client/src/smart-client.ts
+++ b/ts/client/src/smart-client.ts
@@ -124,32 +124,18 @@ export class SmartClient {
         }
     }
 
-    protected checkIfAborted<T>(res: T) {
-        // client will only ever return undefined if the query was cancelled
-        if (res === undefined) {
-            this.dispose();
-            throw new Error("Query has been cancelled");
-        }
-    }
-
     public async query<T extends QueryResultRow>(query: string, values?: any[]): Promise<QueryResult<T>> {
         this.ensureLiving();
 
         this.queryLogger?.(query, values);
-        const res = await this.client.query<T>(query, values);
-        this.checkIfAborted(res);
-
-        return res;
+        return await this.client.query<T>(query, values);
     }
 
     public async queryArray<T extends any[]>(query: string, values?: any[]): Promise<QueryArrayResult<T>> {
         this.ensureLiving();
 
         this.queryLogger?.(query, values);
-        const res = await this.client.query<T>({ text: query, values, rowMode: "array" });
-        this.checkIfAborted(res);
-
-        return res;
+        return await this.client.query<T>({ text: query, values, rowMode: "array" });
     }
 
     public queryStream<T, O extends StreamOptions>(
@@ -163,16 +149,12 @@ export class SmartClient {
         try {
             this.queryLogger?.(query, values);
             const cursor = this.client.query(new Cursor(query, values));
-            this.checkIfAborted(cursor);
-
-            const abortCheck = this.checkIfAborted.bind(this);
 
             const batchSize = options.batchSize;
             if (batchSize === undefined) {
                 const generator = async function* () {
                     while (true) {
                         const result = await cursor.read(1);
-                        abortCheck(result);
 
                         if (result.length === 0) {
                             break;
@@ -187,7 +169,6 @@ export class SmartClient {
                 const generator = async function* () {
                     while (true) {
                         const result = await cursor.read(batchSize);
-                        abortCheck(result);
 
                         if (result.length === 0) {
                             break;
@@ -247,19 +228,16 @@ export class SmartClient {
             this.inTx = true;
 
             if (this.txDepth === 0) {
-                const res = await this.client.query("BEGIN;");
-                this.checkIfAborted(res);
+                await this.client.query("BEGIN;");
             } else {
-                const res = await this.client.query(`SAVEPOINT S${this.txDepth};`);
-                this.checkIfAborted(res);
+                await this.client.query(`SAVEPOINT S${this.txDepth};`);
             }
 
             this.active = false;
             const result = await CurrentTransaction.run(newClient, () => fn(newClient));
 
             if (this.txDepth === 0) {
-                const res = await this.client.query("COMMIT;");
-                this.checkIfAborted(res);
+                await this.client.query("COMMIT;");
             }
 
             // This is a bit of a misnomer in the sense that if this `tx` is not at the root
@@ -278,15 +256,13 @@ export class SmartClient {
             console.error("Error in transaction", e);
 
             if (this.txDepth === 0) {
-                const res = await this.client.query("ROLLBACK;");
-                this.checkIfAborted(res);
+                await this.client.query("ROLLBACK;");
 
                 this.active = true;
                 await newClient.trigger("rollback");
                 await this.trigger("rollback");
             } else {
-                const res = await this.client.query(`ROLLBACK TO S${this.txDepth - 1}`);
-                this.checkIfAborted(res);
+                await this.client.query(`ROLLBACK TO S${this.txDepth - 1}`);
 
                 this.active = true;
                 await newClient.trigger("rollback");

--- a/ts/client/src/smart-client.ts
+++ b/ts/client/src/smart-client.ts
@@ -128,14 +128,14 @@ export class SmartClient {
         this.ensureLiving();
 
         this.queryLogger?.(query, values);
-        return await this.client.query<T>(query, values);
+        return this.client.query<T>(query, values);
     }
 
     public async queryArray<T extends any[]>(query: string, values?: any[]): Promise<QueryArrayResult<T>> {
         this.ensureLiving();
 
         this.queryLogger?.(query, values);
-        return await this.client.query<T>({ text: query, values, rowMode: "array" });
+        return this.client.query<T>({ text: query, values, rowMode: "array" });
     }
 
     public queryStream<T, O extends StreamOptions>(
@@ -149,13 +149,11 @@ export class SmartClient {
         try {
             this.queryLogger?.(query, values);
             const cursor = this.client.query(new Cursor(query, values));
-
             const batchSize = options.batchSize;
             if (batchSize === undefined) {
                 const generator = async function* () {
                     while (true) {
                         const result = await cursor.read(1);
-
                         if (result.length === 0) {
                             break;
                         }
@@ -169,7 +167,6 @@ export class SmartClient {
                 const generator = async function* () {
                     while (true) {
                         const result = await cursor.read(batchSize);
-
                         if (result.length === 0) {
                             break;
                         }

--- a/ts/client/src/smart-client.ts
+++ b/ts/client/src/smart-client.ts
@@ -146,7 +146,7 @@ export class SmartClient {
         this.ensureLiving();
 
         this.queryLogger?.(query, values);
-        const res = this.client.query<T>({ text: query, values, rowMode: "array" });
+        const res = await this.client.query<T>({ text: query, values, rowMode: "array" });
         this.checkIfAborted(res);
 
         return res;

--- a/ts/client/yarn.lock
+++ b/ts/client/yarn.lock
@@ -124,8 +124,8 @@ __metadata:
     pg-cursor: "*"
     zod: "*"
   bin:
-    pq-migration: ./dist/bin/pq-migration.js
-    pq-new: ./dist/bin/pq-new.js
+    piqued-migrate: ./dist/bin/piqued-migrate.js
+    pqm: ./dist/bin/piqued-migrate.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Check for signature query abort type after every raw `client.query` call.